### PR TITLE
Update error handling

### DIFF
--- a/backend-rs/Cargo.toml
+++ b/backend-rs/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.86"
 axum = { version = "0.7", features = ["tracing"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 dotenv = "0.15"

--- a/backend-rs/src/api/flake.rs
+++ b/backend-rs/src/api/flake.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use axum::{
     extract::{Query, State},
     Json,
@@ -6,7 +7,7 @@ use chrono::NaiveDateTime;
 use opensearch::{OpenSearch, SearchParts};
 use serde_json::{json, Value};
 use sqlx::{postgres::PgRow, FromRow, Pool, Postgres, Row};
-use std::{collections::HashMap, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use crate::common::{AppError, AppState};
 
@@ -19,6 +20,26 @@ struct FlakeRelease {
     version: String,
     description: String,
     created_at: NaiveDateTime,
+}
+
+impl Eq for FlakeRelease {}
+
+impl Ord for FlakeRelease {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl PartialOrd for FlakeRelease {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for FlakeRelease {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
 }
 
 impl FromRow<'_, PgRow> for FlakeRelease {
@@ -53,7 +74,7 @@ pub async fn get_flake(
 
         if !releases.is_empty() {
             // Should this be done by the DB?
-            releases.sort_by(|a, b| hits[&b.id].partial_cmp(&hits[&a.id]).unwrap());
+            releases.sort();
         }
 
         releases
@@ -116,10 +137,7 @@ async fn get_flakes(pool: &Pool<Postgres>) -> Result<Vec<FlakeRelease>, sqlx::Er
     Ok(releases)
 }
 
-async fn search_flakes(
-    opensearch: &OpenSearch,
-    q: &String,
-) -> Result<HashMap<i32, f64>, opensearch::Error> {
+async fn search_flakes(opensearch: &OpenSearch, q: &String) -> Result<HashMap<i32, f64>, AppError> {
     let res = opensearch
         .search(SearchParts::Index(&["flakes"]))
         .size(10)
@@ -146,12 +164,21 @@ async fn search_flakes(
     // TODO: Remove this unwrap, use fold or map to create the HashMap
     let mut hits: HashMap<i32, f64> = HashMap::new();
 
-    for hit in res["hits"]["hits"].as_array().unwrap() {
-        // TODO: properly handle errors
-        hits.insert(
-            hit["_id"].as_str().unwrap().parse().unwrap(),
-            hit["_score"].as_f64().unwrap(),
-        );
+    let hit_res = res["hits"]["hits"]
+        .as_array()
+        .context("failed to extract hits from open search response")?;
+
+    for hit in hit_res {
+        let id = hit["_id"]
+            .as_str()
+            .context("failed to read id as string from open search hit")?
+            .parse()
+            .context("failed to parse id from open search hit")?;
+        let score = hit["_score"]
+            .as_f64()
+            .context("failed to parse score from open search hit")?;
+
+        hits.insert(id, score);
     }
 
     Ok(hits)

--- a/backend-rs/src/common.rs
+++ b/backend-rs/src/common.rs
@@ -7,37 +7,17 @@ pub struct AppState {
     pub pool: PgPool,
 }
 
-pub enum AppError {
-    OpenSearchError(opensearch::Error),
-    SqlxError(sqlx::Error),
-    UnexpectedError(anyhow::Error),
-}
-
-impl From<opensearch::Error> for AppError {
-    fn from(value: opensearch::Error) -> Self {
-        AppError::OpenSearchError(value)
-    }
-}
-
-impl From<sqlx::Error> for AppError {
-    fn from(value: sqlx::Error) -> Self {
-        AppError::SqlxError(value)
-    }
-}
+pub struct AppError(anyhow::Error);
 
 impl From<anyhow::Error> for AppError {
     fn from(value: anyhow::Error) -> Self {
-        AppError::UnexpectedError(value)
+        AppError(value)
     }
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        let body = match self {
-            AppError::OpenSearchError(error) => error.to_string(),
-            AppError::SqlxError(error) => error.to_string(),
-            AppError::UnexpectedError(error) => error.to_string(),
-        };
+       let body = self.0.to_string();
         (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
     }
 }

--- a/backend-rs/src/common.rs
+++ b/backend-rs/src/common.rs
@@ -10,6 +10,7 @@ pub struct AppState {
 pub enum AppError {
     OpenSearchError(opensearch::Error),
     SqlxError(sqlx::Error),
+    UnexpectedError(anyhow::Error),
 }
 
 impl From<opensearch::Error> for AppError {
@@ -24,11 +25,18 @@ impl From<sqlx::Error> for AppError {
     }
 }
 
+impl From<anyhow::Error> for AppError {
+    fn from(value: anyhow::Error) -> Self {
+        AppError::UnexpectedError(value)
+    }
+}
+
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
         let body = match self {
             AppError::OpenSearchError(error) => error.to_string(),
             AppError::SqlxError(error) => error.to_string(),
+            AppError::UnexpectedError(error) => error.to_string(),
         };
         (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
     }


### PR DESCRIPTION
Updates the usage of `unwrap` with `anyhow::context` so that they are wrapped in a `anyhow::Error` with some specific context.

Usage of `unwrap` in the startup phase of the app are replaced with `expect` so that it still panics, but we have more context as to what failed.